### PR TITLE
src: Use QSettings to store the configuration

### DIFF
--- a/res/i18n/yggtray_ru.ts
+++ b/res/i18n/yggtray_ru.ts
@@ -67,6 +67,14 @@
   <context>
     <name>QObject</name>
     <message>
+      <source>Settings migration error</source>
+      <translation>Ошибка миграции настроек</translation>
+    </message>
+    <message>
+      <source>Cannot open the old settings file: </source>
+      <translation>Невозможно открыть файл настроек: </translation>
+    </message>
+    <message>
       <source>yes</source>
       <translation>да</translation>
     </message>

--- a/src/SetupWizard.cpp
+++ b/src/SetupWizard.cpp
@@ -1,3 +1,4 @@
+#include <QDebug>
 #include <QDir>
 #include <QFile>
 #include <QInputDialog>
@@ -11,7 +12,45 @@
 
 #include "SetupWizard.h"
 
+/**
+ * Migrate old settings to QSettings.  Delete the old settings file.
+ * @return true if the migration is done, false otherwise.
+ */
+bool SetupWizard::migrateSettings() {
+    QFile configFile(getConfigFilePath());
+    if (! configFile.exists()) {
+        qDebug() << "No migration is needed.";
+        return false;
+    }
+
+    if (! configFile.open(QFile::ReadOnly | QFile::Text)) {
+        qCritical() << "Cannot open the old settings file:"
+                    << configFile.fileName();
+        QMessageBox::critical(
+            nullptr,
+            QObject::tr("Settings migration error"),
+            QObject::tr("Cannot open the old settings file: ")
+            + configFile.fileName());
+        return false;
+    }
+    qDebug() << "Settings file migration:"
+             << configFile.fileName() << " -> " << settings->fileName();
+    QTextStream in(&configFile);
+    QString content = in.readAll();
+    configFile.close();
+
+    settings->setValue("setup_wizard/setup_complete",
+                       content.contains("setup_complete=true"));
+    configFile.remove();
+    qDebug() << "Settings file migration is finished.";
+    return true;
+}
+
 void SetupWizard::run(bool forceRun) {
+
+    // TODO: Remove this migration in the following Yggtray versions.
+    migrateSettings();
+
     if (!forceRun && isSetupComplete()) {
         return; // Skip if setup is already complete and not triggered via CLI
     }

--- a/src/SetupWizard.cpp
+++ b/src/SetupWizard.cpp
@@ -177,40 +177,12 @@ QString SetupWizard::getConfigFilePath() const {
 }
 
 bool SetupWizard::isSetupComplete() {
-    QFile configFile(getConfigFilePath());
-    if (!configFile.exists()) {
-        return false;
-    }
-
-    if (!configFile.open(QFile::ReadOnly | QFile::Text)) {
-        return false;
-    }
-
-    QTextStream in(&configFile);
-    QString content = in.readAll();
-    configFile.close();
-
-    return content.contains("setup_complete=true");
+    return settings->value("setup_wizard/setup_complete",
+                           false).toBool();
 }
 
 void SetupWizard::markSetupComplete() {
-    QString configFilePath = getConfigFilePath();
-    QDir configDir(QFileInfo(configFilePath).absolutePath());
-    if (!configDir.exists()) {
-        configDir.mkpath(".");
-    }
-
-    QFile configFile(configFilePath);
-    if (configFile.open(QFile::WriteOnly | QFile::Text)) {
-        QTextStream out(&configFile);
-        out << "setup_complete=true\n";
-        configFile.close();
-    } else {
-        QMessageBox::warning(
-            nullptr,
-            QObject::tr("Setup Wizard"),
-            QObject::tr("Failed to mark the setup as complete."));
-    }
+    settings->setValue("setup_wizard/setup_complete", true);
 }
 
 QString SetupWizard::promptAction(const QString &message,

--- a/src/SetupWizard.h
+++ b/src/SetupWizard.h
@@ -10,12 +10,14 @@
 #ifndef SETUPWIZARD_H
 #define SETUPWIZARD_H
 
+#include <memory>
 #include <QDir>
 #include <QFile>
 #include <QInputDialog>
 #include <QMap>
 #include <QMessageBox>
 #include <QProcess>
+#include <QSettings>
 #include <QStandardPaths>
 #include <QString>
 #include <QTextStream>
@@ -39,6 +41,11 @@ public:
         QString installCmd;      // Full installation command
     };
 
+    SetupWizard(std::shared_ptr<QSettings> settings)
+        : settings(settings) {
+        // Do nothing.
+    }
+
     /**
      * @brief Runs the setup wizard if not already completed.
      * @param forceRun If true, the wizard runs regardless of the config file
@@ -47,6 +54,8 @@ public:
     void run(bool forceRun = false);
 
 private:
+    std::shared_ptr<QSettings> settings;
+
     /**
      * @brief Ensures the main Yggdrasil configuration file
      * (yggdrasil.conf) exists.

--- a/src/SetupWizard.h
+++ b/src/SetupWizard.h
@@ -157,6 +157,11 @@ private:
      * @param distroInfo Distribution information containing service name
      */
     void enableIp6tablesService(const DistroInfo &distroInfo);
+
+    /**
+     * Migrate old settings to QSettings.
+     */
+    bool migrateSettings();
 };
 
 #endif // SETUPWIZARD_H

--- a/src/tray.cpp
+++ b/src/tray.cpp
@@ -15,6 +15,7 @@
 #include <QMenu>
 #include <QMessageBox>
 #include <QPixmap>
+#include <QSettings>
 #include <QSharedMemory>
 #include <QStringList>
 #include <QSystemTrayIcon>
@@ -242,6 +243,11 @@ void printHelp(const char* program) {
  */
 int main(int argc, char *argv[]) {
     QApplication app(argc, argv);
+    auto settings = std::make_shared<QSettings>(
+        QSettings::IniFormat,
+        QSettings::UserScope,
+        "github.com/the-nexi",
+        "Yggtray");
 
     QTranslator translator;
     if (translator.load(":/translations/yggtray.qm")) {
@@ -299,7 +305,7 @@ int main(int argc, char *argv[]) {
 
     QApplication::setQuitOnLastWindowClosed(false);
 
-    SetupWizard wizard;
+    SetupWizard wizard(settings);
     wizard.run(forceSetup);
 
     YggdrasilTray tray(debugMode);


### PR DESCRIPTION
This pull request migrates the Yggtray configuration store to QSettings.  It simplifies configuration store and allows us to store additional settings without rolling out a lot of custom code.

* src/tray.cpp (main): Use QSettings to store Yggtray configuration instead of a custom implementation.
* src/SetupWizard.h (SetupWizard::SetupWizard): New constructor. (SetupWizard): Add "settings" field.
* src/SetupWizard.cpp (SetupWizard::isSetupComplete) (SetupWizard::markSetupComplete): Use QSettings for settings.