### PR TITLE
Improve yggdrasil configuraiton patcher

### DIFF
--- a/res/scripts/update-peers.sh
+++ b/res/scripts/update-peers.sh
@@ -51,23 +51,23 @@ trap 'rm -f "$TEMP_FILE" "$TEMP_FILE.peers"' EXIT
     # Process each line, trim whitespace, ensure proper format
     COUNT=0
     MAX_PEERS=15  # Limit to 15 peers as mentioned in the comments
-    
+
     while IFS= read -r line || [ -n "$line" ]; do
         # Skip empty lines
         [ -z "$line" ] && continue
-        
+
         # Trim whitespace
         line=$(echo "$line" | sed -e 's/^[[:space:]]*//' -e 's/[[:space:]]*$//')
-        
+
         # Skip if empty after trimming
         [ -z "$line" ] && continue
-        
+
         # Enforce proper URI format - must be tls://, tcp:// or quic:// followed by host and port
         if ! echo "$line" | grep -qE '^(tls|tcp|quic)://[^[:space:]]+:[0-9]+$'; then
             [ "$VERBOSE_MODE" = "1" ] && echo "Debug: Skipping invalid peer URI format: $line" >&2
             continue
         fi
-        
+
         # Count the peers we're adding (up to MAX_PEERS)
         COUNT=$((COUNT + 1))
         if [ "$COUNT" -le "$MAX_PEERS" ]; then
@@ -98,20 +98,20 @@ cp "$CONFIG_FILE" "$TIMESTAMPED_BACKUP_FILE"
 [ "$VERBOSE_MODE" = "1" ] && echo "Debug: Updating configuration..." >&2
 awk '
   BEGIN { in_peers_section = 0; }
-  
+
   # When we find the Peers section opening
   /^[[:space:]]*Peers[[:space:]]*:[[:space:]]*\[/ {
     in_peers_section = 1;
     system("cat \"'"$TEMP_FILE.peers"'\"");
     next;
   }
-  
+
   # When we find the Peers section closing
   in_peers_section && /^[[:space:]]*\]/ {
     in_peers_section = 0;
     next;
   }
-  
+
   # Print all lines that are not part of the Peers section
   !in_peers_section {
     print;

--- a/res/scripts/update-peers.sh
+++ b/res/scripts/update-peers.sh
@@ -47,7 +47,7 @@ trap 'rm -f "$TEMP_FILE" "$TEMP_FILE.peers"' EXIT
 # Process and clean up the peers file - trim whitespace, ensure proper formatting
 [ "$VERBOSE_MODE" = "1" ] && echo "Debug: Processing peer list from $PEERS_FILE..." >&2
 {
-    echo "Peers: ["
+    echo "  Peers: ["
     # Process each line, trim whitespace, ensure proper format
     COUNT=0
     MAX_PEERS=15  # Limit to 15 peers as mentioned in the comments
@@ -71,15 +71,14 @@ trap 'rm -f "$TEMP_FILE" "$TEMP_FILE.peers"' EXIT
         # Count the peers we're adding (up to MAX_PEERS)
         COUNT=$((COUNT + 1))
         if [ "$COUNT" -le "$MAX_PEERS" ]; then
-            # Output each peer on its own line without commas or indentation
-            echo "$line"
+            echo "    $line"
             [ "$VERBOSE_MODE" = "1" ] && echo "Debug: Added peer $COUNT: $line" >&2
         else
             [ "$VERBOSE_MODE" = "1" ] && echo "Debug: Reached max peers limit ($MAX_PEERS), skipping: $line" >&2
             break
         fi
     done < "$PEERS_FILE"
-    echo "]"
+    echo "  ]"
 } > "$TEMP_FILE.peers"
 
 # Check if the file has any peers

--- a/src/PeerManager.cpp
+++ b/src/PeerManager.cpp
@@ -15,6 +15,9 @@
 
 #include "PeerManager.h"
 
+static const QString SCRIPT_PATH = "/tmp/yggtray-update-peers.sh";
+static const QString POLICY_PATH = "/tmp/org.yggtray.updatepeers.policy";
+
 /**
  * @brief Constructor for PeerTestRunnable
  * @param peer The peer data to test.
@@ -392,19 +395,16 @@ bool PeerManager::updateConfig(const QList<PeerData>& selectedPeers) {
         });
 
     // Extract update script to /tmp
-    QString scriptPath = "/tmp/yggtray-update-peers.sh";
-    QString policyPath = "/tmp/org.yggtray.updatepeers.policy";
-
-    if (!extractResource(":/scripts/update-peers.sh", scriptPath)) {
+    if (!extractResource(":/scripts/update-peers.sh", SCRIPT_PATH)) {
         qDebug() << "[PeerManager::updateConfig]"
                  << "Failed to extract update script";
         return false;
     }
 
     if (!extractResource(":/polkit/org.yggtray.updatepeers.policy",
-                         policyPath)) {
+                         POLICY_PATH)) {
         // Clean up script if policy extraction fails
-        QFile::remove(scriptPath);
+        QFile::remove(SCRIPT_PATH);
         qDebug() << "[PeerManager::updateConfig]"
                  << "Failed to extract policy file";
         return false;
@@ -465,9 +465,9 @@ bool PeerManager::updateConfig(const QList<PeerData>& selectedPeers) {
     QProcess process;
     QStringList args;
     if (debugMode) {
-        args << "sh" << scriptPath << "--verbose" << peersFile.fileName();
+        args << "sh" << SCRIPT_PATH << "--verbose" << peersFile.fileName();
     } else {
-        args << "sh" << scriptPath << peersFile.fileName();
+        args << "sh" << SCRIPT_PATH << peersFile.fileName();
     }
 
     qDebug() << "[PeerManager::updateConfig]"
@@ -477,8 +477,8 @@ bool PeerManager::updateConfig(const QList<PeerData>& selectedPeers) {
     if (!process.waitForFinished(SCRIPT_TIMEOUT_MS)) {
         QString errorMsg = "Update script timed out";
         qDebug() << "[PeerManager::updateConfig] Error:" << errorMsg;
-        QFile::remove(scriptPath);
-        QFile::remove(policyPath);
+        QFile::remove(SCRIPT_PATH);
+        QFile::remove(POLICY_PATH);
         emit error(errorMsg);
         return false;
     }
@@ -497,8 +497,8 @@ bool PeerManager::updateConfig(const QList<PeerData>& selectedPeers) {
                      << "treating as successful";
 
             // Clean up temporary files
-            QFile::remove(scriptPath);
-            QFile::remove(policyPath);
+            QFile::remove(SCRIPT_PATH);
+            QFile::remove(POLICY_PATH);
             return true;
         }
 
@@ -512,8 +512,8 @@ bool PeerManager::updateConfig(const QList<PeerData>& selectedPeers) {
         }
 
         qDebug() << "[PeerManager::updateConfig] Error:" << errorMsg;
-        QFile::remove(scriptPath);
-        QFile::remove(policyPath);
+        QFile::remove(SCRIPT_PATH);
+        QFile::remove(POLICY_PATH);
         emit error(errorMsg);
         return false;
     }
@@ -527,8 +527,8 @@ bool PeerManager::updateConfig(const QList<PeerData>& selectedPeers) {
     }
 
     // Clean up temporary files
-    QFile::remove(scriptPath);
-    QFile::remove(policyPath);
+    QFile::remove(SCRIPT_PATH);
+    QFile::remove(POLICY_PATH);
     return true;
 }
 

--- a/src/PeerManager.cpp
+++ b/src/PeerManager.cpp
@@ -369,6 +369,16 @@ bool PeerManager::extractResource(const QString& resourcePath,
 }
 
 /**
+ * @brief Print a peer data into a stream in a format suitable for adding to the
+ * Yggdrasil config.
+ * @param stream A text stream to print data to.
+ * @param peer A peer data to be printed.
+ */
+void formatPeer(QTextStream& stream, const PeerData& peer) {
+    stream << peer.host << "\n";
+}
+
+/**
  * @brief Updates Yggdrasil configuration with selected peers
  * @param selectedPeers List of peers to include in configuration
  * @return true if configuration was successfully updated
@@ -426,7 +436,7 @@ bool PeerManager::updateConfig(const QList<PeerData>& selectedPeers) {
     // First try to write only valid peers
     for (const auto& peer : sortedPeers) {
         if (peer.isValid) {
-            stream << peer.host << "\n";
+            formatPeer(stream, peer);
             validPeerCount++;
         }
     }
@@ -439,7 +449,7 @@ bool PeerManager::updateConfig(const QList<PeerData>& selectedPeers) {
 
         // Use all peers instead, sorted by latency if available
         for (const auto& peer : sortedPeers) {
-            stream << peer.host << "\n";
+            formatPeer(stream, peer);
         }
 
         qDebug() << "[PeerManager::updateConfig] Writing"

--- a/src/PeerManager.cpp
+++ b/src/PeerManager.cpp
@@ -379,6 +379,17 @@ void formatPeer(QTextStream& stream, const PeerData& peer) {
 }
 
 /**
+ * @brief Write a list of peers into an output stream.
+ * @param stream An output text stream to write data to.
+ * @param peers A list of peers to write.
+ */
+void writePeers(QTextStream& stream, const QList<PeerData>& peers) {
+    for (const auto& peer : peers) {
+        formatPeer(stream, peer);
+    }
+}
+
+/**
  * @brief Updates Yggdrasil configuration with selected peers
  * @param selectedPeers List of peers to include in configuration
  * @return true if configuration was successfully updated
@@ -403,6 +414,13 @@ bool PeerManager::updateConfig(const QList<PeerData>& selectedPeers) {
             }
             return a.isValid > b.isValid;
         });
+
+    QList<PeerData> validPeers;
+    validPeers.reserve(sortedPeers.size());
+    std::copy_if(sortedPeers.begin(),
+                 sortedPeers.end(),
+                 std::back_inserter(validPeers),
+                 [](const PeerData& p) { return p.isValid; });
 
     // Extract update script to /tmp
     if (!extractResource(":/scripts/update-peers.sh", SCRIPT_PATH)) {
@@ -431,35 +449,26 @@ bool PeerManager::updateConfig(const QList<PeerData>& selectedPeers) {
 
     // Write peers to temporary file
     QTextStream stream(&peersFile);
-    int validPeerCount = 0;
 
     // First try to write only valid peers
-    for (const auto& peer : sortedPeers) {
-        if (peer.isValid) {
-            formatPeer(stream, peer);
-            validPeerCount++;
-        }
-    }
-
-    // If no valid peers, use all peers as a fallback
-    if (validPeerCount == 0) {
+    if (validPeers.size() > 0) {
+        qDebug() << "[PeerManager::updateConfig] Writing"
+                 << totalValidPeers
+                 << "valid peers to config (up to"
+                 << MAX_PEERS << "will be used)";
+        writePeers(stream, validPeers);
+    } else {
+        // If no valid peers, use all peers as a fallback
         qDebug() << "[PeerManager::updateConfig]"
                  << "Warning: No valid peers found, using all peers as fallback";
         stream.seek(0); // Reset the stream position
 
         // Use all peers instead, sorted by latency if available
-        for (const auto& peer : sortedPeers) {
-            formatPeer(stream, peer);
-        }
+        writePeers(stream, sortedPeers);
 
         qDebug() << "[PeerManager::updateConfig] Writing"
                  << sortedPeers.count()
                  << "peers to config (up to" << MAX_PEERS << "will be used)";
-    } else {
-        qDebug() << "[PeerManager::updateConfig] Writing"
-                 << validPeerCount
-                 << "valid peers to config (up to"
-                 << MAX_PEERS << "will be used)";
     }
 
     stream.flush();

--- a/src/PeerManager.cpp
+++ b/src/PeerManager.cpp
@@ -398,13 +398,6 @@ bool PeerManager::updateConfig(const QList<PeerData>& selectedPeers) {
     qDebug() << "[PeerManager::updateConfig] Starting update with"
              << selectedPeers.count() << "peers";
 
-    // Count valid peers for logging
-    int totalValidPeers
-        = std::count_if(selectedPeers.begin(), selectedPeers.end(),
-                        [](const PeerData& p) { return p.isValid; });
-    qDebug() << "[PeerManager::updateConfig] Valid peers in selection:"
-             << totalValidPeers;
-
     // Sort peers by latency (lowest first)
     QList<PeerData> sortedPeers = selectedPeers;
     std::sort(sortedPeers.begin(), sortedPeers.end(),
@@ -421,6 +414,8 @@ bool PeerManager::updateConfig(const QList<PeerData>& selectedPeers) {
                  sortedPeers.end(),
                  std::back_inserter(validPeers),
                  [](const PeerData& p) { return p.isValid; });
+    qDebug() << "[PeerManager::updateConfig] Valid peers in selection:"
+             << validPeers.size();
 
     // Extract update script to /tmp
     if (!extractResource(":/scripts/update-peers.sh", SCRIPT_PATH)) {
@@ -453,7 +448,7 @@ bool PeerManager::updateConfig(const QList<PeerData>& selectedPeers) {
     // First try to write only valid peers
     if (validPeers.size() > 0) {
         qDebug() << "[PeerManager::updateConfig] Writing"
-                 << totalValidPeers
+                 << validPeers.size()
                  << "valid peers to config (up to"
                  << MAX_PEERS << "will be used)";
         writePeers(stream, validPeers);

--- a/src/PeerManager.h
+++ b/src/PeerManager.h
@@ -213,5 +213,6 @@ private:
 // Auxiliary procedures.
 
 void formatPeer(QTextStream& stream, const PeerData& peer);
+void writePeers(QTextStream& stream, const QList<PeerData>& peers);
 
 #endif // PEERMANAGER_H

--- a/src/PeerManager.h
+++ b/src/PeerManager.h
@@ -209,4 +209,9 @@ private:
     bool debugMode;
 };
 
+
+// Auxiliary procedures.
+
+void formatPeer(QTextStream& stream, const PeerData& peer);
+
 #endif // PEERMANAGER_H

--- a/tests/unit/test_peermanager.cpp
+++ b/tests/unit/test_peermanager.cpp
@@ -21,8 +21,10 @@ START_TEST(test_formatPeer) {
     stream.flush();
     tmpFile.seek(0);
     QString fileContent = QString::fromUtf8(tmpFile.readAll());
+    QString expectedResult =
+        "tls://example.com\n";
     ck_assert_str_eq(fileContent.toUtf8().constData(),
-                     HOST.toUtf8().constData());
+                     expectedResult.toUtf8().constData());
 }
 
 // Write a peer data into a temporary file, read back the file contents and
@@ -48,8 +50,11 @@ START_TEST(test_writePeers) {
     stream.flush();
     tmpFile.seek(0);
     QString fileContent = QString::fromUtf8(tmpFile.readAll());
+    QString expectedResult =
+        "tls://example.com:1000\n"
+        "tls://example.com:1001\n";
     ck_assert_str_eq(fileContent.toUtf8().constData(),
-                     "tls://example.com:1000\ntls://example.com:1001\n");
+                     expectedResult.toUtf8().constData());
 }
 
 // Test getHostname logic

--- a/tests/unit/test_peermanager.cpp
+++ b/tests/unit/test_peermanager.cpp
@@ -6,6 +6,25 @@
 #include <QtTest/QtTest>
 #include "../../src/PeerManager.h"
 
+// Write a peer data into a temporary file, read back the file contents and
+// compare with the expected result.
+START_TEST(test_formatPeer) {
+    const QString HOST = "tls://example.com";
+    QTemporaryFile tmpFile;
+    ck_assert(tmpFile.open());
+    QTextStream stream(&tmpFile);
+    PeerData peer;
+    peer.host = HOST;
+    peer.latency = 10;
+    peer.isValid = true;
+    formatPeer(stream, peer);
+    stream.flush();
+    tmpFile.seek(0);
+    QString fileContent = QString::fromUtf8(tmpFile.readAll());
+    ck_assert_str_eq(fileContent.toUtf8().constData(),
+                     HOST.toUtf8().constData());
+}
+
 // Test getHostname logic
 START_TEST(test_getHostname_basic)
 {
@@ -253,6 +272,7 @@ Suite* peermanager_suite(void)
     Suite* s = suite_create("PeerManager");
     TCase* tc = tcase_create("Core");
 
+    tcase_add_test(tc, test_formatPeer);
     tcase_add_test(tc, test_getHostname_basic);
     tcase_add_test(tc, test_exportPeersToCsv_basic);
     tcase_add_test(tc, test_peersDiscovered_signal);

--- a/tests/unit/test_peermanager.cpp
+++ b/tests/unit/test_peermanager.cpp
@@ -25,6 +25,33 @@ START_TEST(test_formatPeer) {
                      HOST.toUtf8().constData());
 }
 
+// Write a peer data into a temporary file, read back the file contents and
+// compare with the expected result.
+START_TEST(test_writePeers) {
+    const QList<QString> HOSTS = {
+        "tls://example.com:1000",
+        "tls://example.com:1001"
+    };
+    QTemporaryFile tmpFile;
+    ck_assert(tmpFile.open());
+    QTextStream stream(&tmpFile);
+    PeerData peer1;
+    peer1.host = HOSTS[0];
+    peer1.latency = 10;
+    peer1.isValid = true;
+    PeerData peer2;
+    peer2.host = HOSTS[1];
+    peer2.latency = 12;
+    peer2.isValid = true;
+    QList<PeerData> peers = { peer1, peer2 };
+    writePeers(stream, peers);
+    stream.flush();
+    tmpFile.seek(0);
+    QString fileContent = QString::fromUtf8(tmpFile.readAll());
+    ck_assert_str_eq(fileContent.toUtf8().constData(),
+                     "tls://example.com:1000\ntls://example.com:1001\n");
+}
+
 // Test getHostname logic
 START_TEST(test_getHostname_basic)
 {
@@ -273,6 +300,7 @@ Suite* peermanager_suite(void)
     TCase* tc = tcase_create("Core");
 
     tcase_add_test(tc, test_formatPeer);
+    tcase_add_test(tc, test_writePeers);
     tcase_add_test(tc, test_getHostname_basic);
     tcase_add_test(tc, test_exportPeersToCsv_basic);
     tcase_add_test(tc, test_peersDiscovered_signal);


### PR DESCRIPTION
Some improvements to the code that patches the Yggdrasil configuration file, namely:
- Move peer formatting and writing code form `PeerManager::updateConfig` to separate procedures.
- Add tests for the peer formatting and writing.
- Keep the proper "Peers" section indentation in the configuration file.