### PR TITLE
Implement private peers configuration

### DIFF
--- a/res/i18n/yggtray_ru.ts
+++ b/res/i18n/yggtray_ru.ts
@@ -294,6 +294,10 @@ Please complete the installation in the terminal window and then click OK to con
       <translation>Настройка приватных пиров</translation>
     </message>
     <message>
+      <source>Write private peers below, one peer per line:</source>
+      <translation>Впишите приватные пиры сюда, по одному на строку:</translation>
+    </message>
+    <message>
       <source>Configure Proxy</source>
       <translation>Настроить прокси</translation>
     </message>

--- a/res/i18n/yggtray_ru.ts
+++ b/res/i18n/yggtray_ru.ts
@@ -286,6 +286,14 @@ Please complete the installation in the terminal window and then click OK to con
       <translation>Прокси...</translation>
     </message>
     <message>
+      <source>Private peers...</source>
+      <translation>Приватные пиры...</translation>
+    </message>
+    <message>
+      <source>Configure private peers</source>
+      <translation>Настройка приватных пиров</translation>
+    </message>
+    <message>
       <source>Configure Proxy</source>
       <translation>Настроить прокси</translation>
     </message>

--- a/res/scripts/update-peers.sh
+++ b/res/scripts/update-peers.sh
@@ -63,7 +63,7 @@ trap 'rm -f "$TEMP_FILE" "$TEMP_FILE.peers"' EXIT
         [ -z "$line" ] && continue
 
         # Enforce proper URI format - must be tls://, tcp:// or quic:// followed by host and port
-        if ! echo "$line" | grep -qE '^(tls|tcp|quic)://[^[:space:]]+:[0-9]+$'; then
+        if ! echo "$line" | grep -qE '(^#.*$)|(^(tls|tcp|quic)://[^[:space:]]+:[0-9]+$)'; then
             [ "$VERBOSE_MODE" = "1" ] && echo "Debug: Skipping invalid peer URI format: $line" >&2
             continue
         fi

--- a/res/scripts/update-peers.sh
+++ b/res/scripts/update-peers.sh
@@ -50,6 +50,7 @@ trap 'rm -f "$TEMP_FILE" "$TEMP_FILE.peers"' EXIT
     echo "  Peers: ["
     # Process each line, trim whitespace, ensure proper format
     COUNT=0
+    VALID_PEERS=0
     MAX_PEERS=15  # Limit to 15 peers as mentioned in the comments
 
     while IFS= read -r line || [ -n "$line" ]; do
@@ -62,13 +63,20 @@ trap 'rm -f "$TEMP_FILE" "$TEMP_FILE.peers"' EXIT
         # Skip if empty after trimming
         [ -z "$line" ] && continue
 
-        # Enforce proper URI format - must be tls://, tcp:// or quic:// followed by host and port
-        if ! echo "$line" | grep -qE '(^#.*$)|(^(tls|tcp|quic)://[^[:space:]]+:[0-9]+$)'; then
+        # Preserve section comments without counting them as peers.
+        if echo "$line" | grep -qE '^#.*$'; then
+            echo "    $line"
+            continue
+        fi
+
+        # Enforce proper URI format - must be tls://, tcp:// or quic:// followed by host and port.
+        if ! echo "$line" | grep -qE '^(tls|tcp|quic)://(\[[A-Fa-f0-9:.]+\]|[A-Za-z0-9.-]+):[0-9]+$'; then
             [ "$VERBOSE_MODE" = "1" ] && echo "Debug: Skipping invalid peer URI format: $line" >&2
             continue
         fi
 
-        # Count the peers we're adding (up to MAX_PEERS)
+        # Count the peers we're adding (up to MAX_PEERS).
+        VALID_PEERS=$((VALID_PEERS + 1))
         COUNT=$((COUNT + 1))
         if [ "$COUNT" -le "$MAX_PEERS" ]; then
             echo "    $line"
@@ -81,8 +89,8 @@ trap 'rm -f "$TEMP_FILE" "$TEMP_FILE.peers"' EXIT
     echo "  ]"
 } > "$TEMP_FILE.peers"
 
-# Check if the file has any peers
-if ! grep -q '[^[:space:]]' "$TEMP_FILE.peers"; then
+# Check if the file has any peers.
+if [ "${VALID_PEERS:-0}" -eq 0 ]; then
     echo "Error: No valid peers found in input file" >&2
     exit 1
 fi

--- a/src/PeerDiscoveryDialog.cpp
+++ b/src/PeerDiscoveryDialog.cpp
@@ -5,6 +5,7 @@
  * Contains implementation of dialog for discovering and managing Yggdrasil peers.
  */
 
+#include <memory>
 #include <QBrush>
 #include <QClipboard>
 #include <QComboBox>
@@ -17,7 +18,9 @@
 #include <QLineEdit>
 #include <QMessageBox>
 #include <QNetworkProxy>
+#include <QPlainTextEdit>
 #include <QPushButton>
+#include <QSettings>
 #include <QSpinBox>
 #include <QTimer>
 #include <QVBoxLayout>
@@ -30,15 +33,19 @@ static const int DEFAULT_DIALOG_HEIGHT = 400;
 
 /**
  * @brief Constructor for PeerDiscoveryDialog
+ * @param settings Application settings
  * @param debugMode Whether to enable debug output
  * @param parent Parent widget
  */
-PeerDiscoveryDialog::PeerDiscoveryDialog(bool debugMode, QWidget *parent)
+PeerDiscoveryDialog::PeerDiscoveryDialog(std::shared_ptr<QSettings> settings,
+                                         bool debugMode,
+                                         QWidget *parent)
     : QDialog(parent)
-    , peerManager(new PeerManager(debugMode, this))
+    , peerManager(new PeerManager(settings, debugMode, this))
     , testedPeers(0)
     , totalPeers(0)
-    , isTesting(false) {
+    , isTesting(false)
+    , settings(settings) {
     setWindowTitle(tr("Peer Discovery"));
     setupUi();
     setupConnections();
@@ -89,6 +96,7 @@ void PeerDiscoveryDialog::setupUi() {
     applyButton = new QPushButton(tr("Apply"), this);
     exportButton = new QPushButton(tr("Export CSV"), this);
     proxyButton = new QPushButton(tr("Proxy..."), this);
+    privatePeersButton = new QPushButton(tr("Private peers..."), this);
     testButton->setEnabled(false);
     applyButton->setEnabled(false);
     exportButton->setEnabled(false);
@@ -98,6 +106,7 @@ void PeerDiscoveryDialog::setupUi() {
     buttonLayout->addWidget(applyButton);
     buttonLayout->addWidget(exportButton);
     buttonLayout->addWidget(proxyButton);
+    buttonLayout->addWidget(privatePeersButton);
     buttonLayout->addStretch();
 
     peerTable = new PeerDiscoveryTableWidget(this);
@@ -154,6 +163,8 @@ void PeerDiscoveryDialog::setupConnections() {
 
     connect(proxyButton, &QPushButton::clicked,
             this, &PeerDiscoveryDialog::onProxyConfigClicked);
+    connect(privatePeersButton, &QPushButton::clicked,
+            this, &PeerDiscoveryDialog::onPrivatePeersClicked);
 }
 
 /**
@@ -516,6 +527,45 @@ void PeerDiscoveryDialog::onProxyConfigClicked() {
             QNetworkProxy proxy(type, host, port, user, pass);
             setPeerFetchProxy(proxy);
         }
+    }
+}
+
+/**
+ * @brief Show the private peer configuration dialog.
+ */
+void PeerDiscoveryDialog::onPrivatePeersClicked() {
+    QDialog dlg(this);
+    dlg.setWindowTitle(tr("Configure private peers"));
+
+    QVBoxLayout* layout = new QVBoxLayout(&dlg);
+
+    QPlainTextEdit *textArea = new QPlainTextEdit(&dlg);
+    layout->addWidget(textArea);
+
+    QDialogButtonBox* buttons
+        = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel,
+                               &dlg);
+    layout->addWidget(buttons);
+
+    QString peers
+        = settings->value("peer_discovery/private_peers", "").toString();
+    textArea->setPlainText(peers.split(",").join("\n"));
+
+    QObject::connect(buttons,
+                     &QDialogButtonBox::accepted,
+                     &dlg,
+                     &QDialog::accept);
+    QObject::connect(buttons,
+                     &QDialogButtonBox::rejected,
+                     &dlg,
+                     &QDialog::reject);
+
+    if (dlg.exec() == QDialog::Accepted) {
+        QString content = textArea->toPlainText();
+        QStringList lines = content.split("\n");
+        QString s = lines.join(",");
+        settings->setValue("peer_discovery/private_peers",
+                           s);
     }
 }
 

--- a/src/PeerDiscoveryDialog.cpp
+++ b/src/PeerDiscoveryDialog.cpp
@@ -408,6 +408,8 @@ void PeerDiscoveryDialog::onApplyClicked() {
     for (const auto& peer : peerList) {
         qDebug() << "Peer in list:"
                  << peer.host
+                 << "isPrivate:"
+                 << peer.isPrivate
                  << "isValid:"
                  << peer.isValid
                  << "latency:"
@@ -434,6 +436,7 @@ void PeerDiscoveryDialog::onApplyClicked() {
         selectedPeers = peerList;
         for (const auto& peer : selectedPeers) {
             qDebug() << "Using peer:" << peer.host
+                     << "isPrivate:" << peer.isPrivate
                      << "isValid:" << peer.isValid
                      << "latency:" << peer.latency;
         }

--- a/src/PeerDiscoveryDialog.cpp
+++ b/src/PeerDiscoveryDialog.cpp
@@ -540,6 +540,9 @@ void PeerDiscoveryDialog::onPrivatePeersClicked() {
     QVBoxLayout* layout = new QVBoxLayout(&dlg);
 
     QPlainTextEdit *textArea = new QPlainTextEdit(&dlg);
+    QLabel* label = new QLabel(
+        tr("Write private peers below, one peer per line:"));
+    layout->addWidget(label);
     layout->addWidget(textArea);
 
     QDialogButtonBox* buttons

--- a/src/PeerDiscoveryDialog.cpp
+++ b/src/PeerDiscoveryDialog.cpp
@@ -546,7 +546,7 @@ void PeerDiscoveryDialog::onPrivatePeersClicked() {
     layout->addWidget(textArea);
 
     QDialogButtonBox* buttons
-        = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel,
+        = new QDialogButtonBox(QDialogButtonBox::Save | QDialogButtonBox::Cancel,
                                &dlg);
     layout->addWidget(buttons);
 

--- a/src/PeerDiscoveryDialog.cpp
+++ b/src/PeerDiscoveryDialog.cpp
@@ -568,10 +568,29 @@ void PeerDiscoveryDialog::onPrivatePeersClicked() {
 
     if (dlg.exec() == QDialog::Accepted) {
         QString content = textArea->toPlainText();
-        QStringList lines = content.split("\n");
-        QString s = lines.join(",");
+        QStringList peers;
+        for (const auto& line : content.split("\n")) {
+            QString peerUri = line.trimmed();
+            if (peerUri.isEmpty()) {
+                continue;
+            }
+            if (!isPeerUriValid(peerUri)) {
+                qDebug() << "[PeerDiscoveryDialog::onPrivatePeersClicked]"
+                         << "Skipping invalid private peer:"
+                         << peerUri;
+                continue;
+            }
+            peers.append(peerUri);
+        }
+        QString s = peers.join(",");
         settings->setValue("peer_discovery/private_peers",
                            s);
+        settings->sync();
+
+        if (isTesting) {
+            stopTesting();
+        }
+        onRefreshClicked();
     }
 }
 

--- a/src/PeerDiscoveryDialog.h
+++ b/src/PeerDiscoveryDialog.h
@@ -1,6 +1,7 @@
 #ifndef PEERDISCOVERYDIALOG_H
 #define PEERDISCOVERYDIALOG_H
 
+#include <memory>
 #include <QCloseEvent>
 #include <QDialog>
 #include <QLabel>
@@ -9,6 +10,7 @@
 #include <QTableWidget>
 #include <QTableWidgetItem>
 #include <QTranslator>
+#include <QSettings>
 
 #include "PeerManager.h"
 
@@ -88,7 +90,8 @@ class PeerDiscoveryDialog : public QDialog {
     Q_OBJECT
 
 public:
-    explicit PeerDiscoveryDialog(bool debugMode = false,
+    explicit PeerDiscoveryDialog(std::shared_ptr<QSettings> settings,
+                                 bool debugMode = false,
                                  QWidget *parent = nullptr);
 
     /**
@@ -114,6 +117,11 @@ private slots:
      */
     void onProxyConfigClicked();
 
+    /**
+     * @brief Show the private peers configuration dialog.
+     */
+    void onPrivatePeersClicked();
+
 private:
     void setupUi();
     void setupConnections();
@@ -121,12 +129,20 @@ private:
     void resetTableUI();
     void setRowColor(int row, bool isValid, bool isTested);
 
+    std::shared_ptr<QSettings> settings;
+
     PeerManager* peerManager;
     QPushButton* refreshButton;
     QPushButton* testButton;
     QPushButton* applyButton;
     QPushButton* exportButton;
     QPushButton* proxyButton;
+
+    /**
+     * @brief A button that opens the private peers manager.
+     */
+    QPushButton* privatePeersButton;
+
     QTableWidget* peerTable;
     QProgressBar* progressBar;
     QLabel* statusLabel;

--- a/src/PeerManager.cpp
+++ b/src/PeerManager.cpp
@@ -566,6 +566,7 @@ void PeerManager::handleNetworkResponse(QNetworkReply* reply) {
     for (auto& p : privatePeers.split(",")) {
         PeerData peer;
         peer.host = p;
+        peer.isPrivate = true;
         privatePeersList.append(peer);
     }
     if (reply->error() == QNetworkReply::NoError) {

--- a/src/PeerManager.cpp
+++ b/src/PeerManager.cpp
@@ -5,10 +5,12 @@
  * Contains implementation of methods for managing Yggdrasil peers.
  */
 
+#include <memory>
 #include <QDebug>
 #include <QFile>
 #include <QProcess>
 #include <QRegularExpression>
+#include <QSettings>
 #include <QTemporaryFile>
 #include <QTextStream>
 #include <QThreadPool>
@@ -228,15 +230,19 @@ bool PeerManager::exportPeersToCsv(const QString& fileName,
 
 /**
  * @brief Constructor for PeerManager
+ * @param settings Application settings
  * @param debugMode Whether to enable debug output
  * @param parent Parent QObject
  */
-PeerManager::PeerManager(bool debugMode, QObject *parent)
+PeerManager::PeerManager(std::shared_ptr<QSettings> settings,
+                         bool debugMode,
+                         QObject *parent)
     : QObject(parent)
     , networkManager(new QNetworkAccessManager(this))
     , threadPool(new QThreadPool(this))
     , cancelTestsFlag(0)
-    , debugMode(debugMode) {
+    , debugMode(debugMode)
+    , settings(settings) {
 
     qRegisterMetaType<PeerData>("PeerData");
     qRegisterMetaType<QList<PeerData>>("QList<PeerData>");
@@ -551,6 +557,17 @@ bool PeerManager::updateConfig(const QList<PeerData>& selectedPeers) {
  * @param reply Network reply containing peer list HTML
  */
 void PeerManager::handleNetworkResponse(QNetworkReply* reply) {
+    QList<PeerData> privatePeersList;
+    QString privatePeers
+        = settings->value("peer_discovery/private_peers", "").toString();
+    qDebug() << "[PeerManager::handleNetworkResponse]"
+             << "Private peers: "
+             << privatePeers;
+    for (auto& p : privatePeers.split(",")) {
+        PeerData peer;
+        peer.host = p;
+        privatePeersList.append(peer);
+    }
     if (reply->error() == QNetworkReply::NoError) {
         QString html = QString::fromUtf8(reply->readAll());
         QList<PeerData> peers;
@@ -570,7 +587,12 @@ void PeerManager::handleNetworkResponse(QNetworkReply* reply) {
                 peers.append(peer);
             }
         }
-
+        if (! privatePeersList.isEmpty()) {
+            // Insert private peers into the beginning of the peer list
+            // so they will be tested first for the latency.
+            privatePeersList += peers;
+            peers = privatePeersList;
+        }
         emit peersDiscovered(peers);
     } else {
         emit error(tr("Failed to fetch peers: %1").arg(reply->errorString()));

--- a/src/PeerManager.cpp
+++ b/src/PeerManager.cpp
@@ -390,7 +390,30 @@ void formatPeer(QTextStream& stream, const PeerData& peer) {
  * @param peers A list of peers to write.
  */
 void writePeers(QTextStream& stream, const QList<PeerData>& peers) {
-    for (const auto& peer : peers) {
+    QList<PeerData> privatePeers;
+    QList<PeerData> publicPeers;
+    privatePeers.reserve(peers.size());
+    std::copy_if(peers.begin(),
+                 peers.end(),
+                 std::back_inserter(privatePeers),
+                 [](const PeerData& p) {
+                     return p.isPrivate;
+                 });
+    publicPeers.reserve(peers.size());
+    std::copy_if(peers.begin(),
+                 peers.end(),
+                 std::back_inserter(publicPeers),
+                 [](const PeerData& p) {
+                     return (! p.isPrivate);
+                 });
+    if (! privatePeers.isEmpty()) {
+        stream << "# Private peers:\n";
+        for (const auto& peer : privatePeers) {
+            formatPeer(stream, peer);
+        }
+    }
+    stream << "# Public peers:\n";
+    for (const auto& peer : publicPeers) {
         formatPeer(stream, peer);
     }
 }

--- a/src/PeerManager.cpp
+++ b/src/PeerManager.cpp
@@ -20,6 +20,13 @@
 static const QString SCRIPT_PATH = "/tmp/yggtray-update-peers.sh";
 static const QString POLICY_PATH = "/tmp/org.yggtray.updatepeers.policy";
 
+bool isPeerUriValid(const QString& peerUri) {
+    static const QRegularExpression re(
+        "^(?:tls|tcp|quic)://(?:\\[[A-Fa-f0-9:.]+\\]|[A-Za-z0-9.-]+):\\d+$"
+    );
+    return re.match(peerUri.trimmed()).hasMatch();
+}
+
 /**
  * @brief Constructor for PeerTestRunnable
  * @param peer The peer data to test.
@@ -454,7 +461,8 @@ bool PeerManager::updateConfig(const QList<PeerData>& selectedPeers) {
                  sortedPeers.end(),
                  std::back_inserter(validPeers),
                  [](const PeerData& p) {
-                     return p.isPrivate || p.isValid;
+                     return isPeerUriValid(p.host)
+                         && (p.isPrivate || p.isValid);
                  });
     qDebug() << "[PeerManager::updateConfig] Valid peers in selection:"
              << validPeers.size();
@@ -503,13 +511,20 @@ bool PeerManager::updateConfig(const QList<PeerData>& selectedPeers) {
         // If no valid peers, use all peers as a fallback
         qDebug() << "[PeerManager::updateConfig]"
                  << "Warning: No valid peers found, using all peers as fallback";
-        stream.seek(0); // Reset the stream position
+        QList<PeerData> fallbackPeers;
+        fallbackPeers.reserve(sortedPeers.size());
+        std::copy_if(sortedPeers.begin(),
+                     sortedPeers.end(),
+                     std::back_inserter(fallbackPeers),
+                     [](const PeerData& p) {
+                         return isPeerUriValid(p.host);
+                     });
 
-        // Use all peers instead, sorted by latency if available
-        writePeers(stream, sortedPeers);
+        // Use URI-valid peers instead, sorted by latency if available.
+        writePeers(stream, fallbackPeers);
 
         qDebug() << "[PeerManager::updateConfig] Writing"
-                 << sortedPeers.count()
+                 << fallbackPeers.count()
                  << "peers to config (up to" << MAX_PEERS << "will be used)";
     }
 
@@ -599,14 +614,27 @@ bool PeerManager::updateConfig(const QList<PeerData>& selectedPeers) {
  */
 void PeerManager::handleNetworkResponse(QNetworkReply* reply) {
     QList<PeerData> privatePeersList;
-    QString privatePeers
-        = settings->value("peer_discovery/private_peers", "").toString();
+    QString privatePeers;
+    if (settings) {
+        privatePeers
+            = settings->value("peer_discovery/private_peers", "").toString();
+    }
     qDebug() << "[PeerManager::handleNetworkResponse]"
              << "Private peers: "
              << privatePeers;
-    for (auto& p : privatePeers.split(",")) {
+    for (const auto& p : privatePeers.split(",")) {
+        QString peerUri = p.trimmed();
+        if (peerUri.isEmpty()) {
+            continue;
+        }
+        if (!isPeerUriValid(peerUri)) {
+            qDebug() << "[PeerManager::handleNetworkResponse]"
+                     << "Skipping invalid private peer:"
+                     << peerUri;
+            continue;
+        }
         PeerData peer;
-        peer.host = p;
+        peer.host = peerUri;
         peer.isPrivate = true;
         privatePeersList.append(peer);
     }

--- a/src/PeerManager.cpp
+++ b/src/PeerManager.cpp
@@ -47,7 +47,6 @@ void PeerTestRunnable::run() {
         qDebug() << "[PeerTestRunnable::run] Skipping test for:"
                  << peerData.host
                  << "(cancelled before start)";
-        emit peerTested(peerData);
         return;
     }
 
@@ -89,7 +88,6 @@ void PeerTestRunnable::run() {
                     pingProcess.waitForFinished(100);
                 }
             }
-            emit peerTested(peerData);
             return;
         }
 
@@ -118,7 +116,6 @@ void PeerTestRunnable::run() {
         qDebug() << "[PeerTestRunnable::run]"
                  << "Test cancelled after ping completion for:"
                  << peerData.host;
-        emit peerTested(peerData);
         return;
     }
 

--- a/src/PeerManager.cpp
+++ b/src/PeerManager.cpp
@@ -408,6 +408,17 @@ bool PeerManager::updateConfig(const QList<PeerData>& selectedPeers) {
     QList<PeerData> sortedPeers = selectedPeers;
     std::sort(sortedPeers.begin(), sortedPeers.end(),
         [](const PeerData& a, const PeerData& b) {
+            if (a.isPrivate) {
+                if (b.isPrivate) {
+                    if (a.isValid && b.isValid) {
+                        return a.latency < b.latency;
+                    }
+                    return a.isValid > b.isValid;
+                }
+                return true;
+            } else if (b.isPrivate) {
+                return false;
+            }
             if (a.isValid && b.isValid) {
                 return a.latency < b.latency;
             }
@@ -419,9 +430,16 @@ bool PeerManager::updateConfig(const QList<PeerData>& selectedPeers) {
     std::copy_if(sortedPeers.begin(),
                  sortedPeers.end(),
                  std::back_inserter(validPeers),
-                 [](const PeerData& p) { return p.isValid; });
+                 [](const PeerData& p) {
+                     return p.isPrivate || p.isValid;
+                 });
     qDebug() << "[PeerManager::updateConfig] Valid peers in selection:"
              << validPeers.size();
+    for (const auto& peer : validPeers) {
+        qDebug() << "[PeerManager::updateConfig]"
+                 << "Using peer:"
+                 << peer.host;
+    }
 
     // Extract update script to /tmp
     if (!extractResource(":/scripts/update-peers.sh", SCRIPT_PATH)) {

--- a/src/PeerManager.h
+++ b/src/PeerManager.h
@@ -23,6 +23,11 @@ struct PeerData {
     int latency = -1;      // in milliseconds
     bool isValid = false;
 
+    /**
+     * @brief Whether the peer is private (that is, added by the user) or not.
+     */
+    bool isPrivate = false;
+
     // Define equality operator based on host
     bool operator==(const PeerData& other) const {
         return host == other.host;

--- a/src/PeerManager.h
+++ b/src/PeerManager.h
@@ -1,6 +1,7 @@
 #ifndef PEERMANAGER_H
 #define PEERMANAGER_H
 
+#include <memory>
 #include <QAtomicInt>
 #include <QElapsedTimer>
 #include <QList>
@@ -10,6 +11,7 @@
 #include <QObject>
 #include <QProcess>
 #include <QRunnable>
+#include <QSettings>
 #include <QThreadPool>
 
 /**
@@ -109,7 +111,8 @@ public:
     static constexpr int MAX_PEERS = 15;
 
 public:
-    explicit PeerManager(bool debugMode = false,
+    explicit PeerManager(std::shared_ptr<QSettings> settings,
+                         bool debugMode = false,
                          QObject *parent = nullptr);
     ~PeerManager();
 
@@ -207,6 +210,7 @@ private:
     QThreadPool* threadPool;
     QAtomicInt cancelTestsFlag;
     bool debugMode;
+    std::shared_ptr<QSettings> settings;
 };
 
 

--- a/src/PeerManager.h
+++ b/src/PeerManager.h
@@ -221,6 +221,7 @@ private:
 
 // Auxiliary procedures.
 
+bool isPeerUriValid(const QString& peerUri);
 void formatPeer(QTextStream& stream, const PeerData& peer);
 void writePeers(QTextStream& stream, const QList<PeerData>& peers);
 

--- a/src/tray.cpp
+++ b/src/tray.cpp
@@ -65,12 +65,15 @@ class YggdrasilTray : public QObject {
     Q_OBJECT
 
 public:
-    explicit YggdrasilTray(bool debugMode = false, QObject *parent = nullptr)
+    explicit YggdrasilTray(std::shared_ptr<QSettings> settings,
+                           bool debugMode = false,
+                           QObject *parent = nullptr)
         : QObject(parent)
         , processRunner()
         , serviceManager("yggdrasil", &processRunner)
         , socketManager(POSSIBLE_YGG_SOCKET_PATHS)
-        , debugMode(debugMode) {
+        , debugMode(debugMode)
+        , settings(settings) {
         trayIcon = new QSystemTrayIcon(this);
         trayIcon->setIcon(QIcon(ICON_NOT_RUNNING));
         trayIcon->setToolTip(TOOLTIP);
@@ -212,9 +215,11 @@ private:
     SocketManager socketManager;
     bool debugMode;
 
+    std::shared_ptr<QSettings> settings;
+
 private slots:
     void showPeerManager() {
-        PeerDiscoveryDialog dialog(debugMode, nullptr);
+        PeerDiscoveryDialog dialog(settings, debugMode, nullptr);
         if (dialog.exec() == QDialog::Accepted) {
             // Restart the service to apply the new configuration
             if (serviceManager.isServiceRunning()) {
@@ -308,7 +313,7 @@ int main(int argc, char *argv[]) {
     SetupWizard wizard(settings);
     wizard.run(forceSetup);
 
-    YggdrasilTray tray(debugMode);
+    YggdrasilTray tray(settings, debugMode);
 
     return app.exec();
 }

--- a/tests/unit/test_main.cpp
+++ b/tests/unit/test_main.cpp
@@ -1,12 +1,14 @@
 #include <check.h>
+#include <QtCore/QCoreApplication>
 #include <stdio.h>
 
 // Forward declarations from other test files
 extern Suite* servicemanager_suite(void);
 extern Suite* peermanager_suite(void);
 
-int main(void)
+int main(int argc, char* argv[])
 {
+    QCoreApplication app(argc, argv);
     int number_failed = 0;
     SRunner* sr = srunner_create(servicemanager_suite());
     srunner_add_suite(sr, peermanager_suite());

--- a/tests/unit/test_peermanager.cpp
+++ b/tests/unit/test_peermanager.cpp
@@ -1,6 +1,9 @@
 #include <check.h>
+#include <memory>
 #include <QtCore/QString>
 #include <QtCore/QList>
+#include <QtCore/QSettings>
+#include <QtCore/QTemporaryDir>
 #include <QtCore/QTemporaryFile>
 #include <QtTest/QSignalSpy>
 #include <QtTest/QtTest>
@@ -51,11 +54,22 @@ START_TEST(test_writePeers) {
     tmpFile.seek(0);
     QString fileContent = QString::fromUtf8(tmpFile.readAll());
     QString expectedResult =
+        "# Public peers:\n"
         "tls://example.com:1000\n"
         "tls://example.com:1001\n";
     ck_assert_str_eq(fileContent.toUtf8().constData(),
                      expectedResult.toUtf8().constData());
 }
+
+START_TEST(test_isPeerUriValid_basic) {
+    ck_assert(isPeerUriValid("tls://example.com:1000"));
+    ck_assert(isPeerUriValid("tcp://192.168.1.1:1234"));
+    ck_assert(isPeerUriValid("quic://[2001:db8::1]:1234"));
+    ck_assert(!isPeerUriValid("tls://example.com"));
+    ck_assert(!isPeerUriValid("tcp://example.com"));
+    ck_assert(!isPeerUriValid(""));
+}
+END_TEST
 
 // Test getHostname logic
 START_TEST(test_getHostname_basic)
@@ -173,6 +187,55 @@ START_TEST(test_peersDiscovered_signal)
     ck_assert_int_eq(peers.size(), 2);
     ck_assert(peers[0].host.contains("tls://[2001:db8::1]:1234"));
     ck_assert(peers[1].host.contains("tcp://192.168.1.1:1234"));
+
+    reply->deleteLater();
+}
+END_TEST
+
+START_TEST(test_peersDiscovered_filters_invalid_private_peers)
+{
+    printf("[PeerManager] test_peersDiscovered_filters_invalid_private_peers: Testing invalid private peers are ignored...\n");
+    QTemporaryDir tempDir;
+    ck_assert(tempDir.isValid());
+    auto settings = std::make_shared<QSettings>(
+        tempDir.filePath("yggtray.ini"),
+        QSettings::IniFormat
+    );
+    settings->setValue(
+        "peer_discovery/private_peers",
+        "tls://example.com,tcp://example.com,quic://spain.magicum.net:36900"
+    );
+    settings->sync();
+
+    PeerManager mgr(settings, false, nullptr);
+
+    QByteArray html =
+        "<html><body>"
+        "<td>tls://public.example:1234</td>"
+        "</body></html>";
+    DummyReply* reply = new DummyReply(html);
+
+    QSignalSpy spy(&mgr, SIGNAL(peersDiscovered(QList<PeerData>)));
+
+    QMetaObject::invokeMethod(
+        &mgr,
+        "handleNetworkResponse",
+        Qt::DirectConnection,
+        Q_ARG(QNetworkReply*, reply)
+    );
+
+    ck_assert_int_eq(spy.count(), 1);
+
+    QList<QVariant> args = spy.takeFirst();
+    QList<PeerData> peers =
+        qvariant_cast<QList<PeerData>>(args.at(0));
+    ck_assert_int_eq(peers.size(), 2);
+    ck_assert(peers[0].isPrivate);
+    ck_assert_str_eq(peers[0].host.toUtf8().constData(),
+                     "quic://spain.magicum.net:36900");
+    ck_assert(!peers[1].isPrivate);
+    ck_assert_str_eq(peers[1].host.toUtf8().constData(),
+                     "tls://public.example:1234");
 
     reply->deleteLater();
 }
@@ -306,9 +369,11 @@ Suite* peermanager_suite(void)
 
     tcase_add_test(tc, test_formatPeer);
     tcase_add_test(tc, test_writePeers);
+    tcase_add_test(tc, test_isPeerUriValid_basic);
     tcase_add_test(tc, test_getHostname_basic);
     tcase_add_test(tc, test_exportPeersToCsv_basic);
     tcase_add_test(tc, test_peersDiscovered_signal);
+    tcase_add_test(tc, test_peersDiscovered_filters_invalid_private_peers);
     tcase_add_test(tc, test_error_signal_network_failure);
     tcase_add_test(tc, test_cancelTests_cancels_all);
     tcase_add_test(tc, test_peersDiscovered_empty_list);

--- a/tests/unit/test_peermanager.cpp
+++ b/tests/unit/test_peermanager.cpp
@@ -61,7 +61,7 @@ START_TEST(test_writePeers) {
 START_TEST(test_getHostname_basic)
 {
     printf("[PeerManager] test_getHostname_basic: Testing getHostname parsing...\n");
-    PeerManager mgr(false, nullptr);
+    PeerManager mgr(nullptr, false, nullptr);
     ck_assert_str_eq(
         mgr.getHostname("tls://[2001:db8::1]:1234").toUtf8().constData(),
         "2001:db8::1"
@@ -85,7 +85,7 @@ END_TEST
 START_TEST(test_exportPeersToCsv_basic)
 {
     printf("[PeerManager] test_exportPeersToCsv_basic: Testing exportPeersToCsv output...\n");
-    PeerManager mgr(false, nullptr);
+    PeerManager mgr(nullptr, false, nullptr);
     QList<PeerData> peers;
     PeerData p1;
     p1.host = "peer1";
@@ -144,7 +144,7 @@ public:
 START_TEST(test_peersDiscovered_signal)
 {
     printf("[PeerManager] test_peersDiscovered_signal: Testing peersDiscovered signal after HTML parsing...\n");
-    PeerManager mgr(false, nullptr);
+    PeerManager mgr(nullptr, false, nullptr);
 
     // Prepare HTML with two peer URIs
     QByteArray html =
@@ -182,7 +182,7 @@ END_TEST
 START_TEST(test_error_signal_network_failure)
 {
     printf("[PeerManager] test_error_signal_network_failure: Testing error signal on network failure...\n");
-    PeerManager mgr(false, nullptr);
+    PeerManager mgr(nullptr, false, nullptr);
 
     DummyReply* reply = new DummyReply("", nullptr);
     reply->setError(QNetworkReply::ConnectionRefusedError, "Connection refused");
@@ -210,7 +210,7 @@ END_TEST
 START_TEST(test_cancelTests_cancels_all)
 {
     printf("[PeerManager] test_cancelTests_cancels_all: Testing that cancelTests cancels all peer checks...\n");
-    PeerManager mgr(false, nullptr);
+    PeerManager mgr(nullptr, false, nullptr);
 
     QSignalSpy spy(&mgr, SIGNAL(peerTested(PeerData)));
 
@@ -247,7 +247,7 @@ END_TEST
 START_TEST(test_peersDiscovered_empty_list)
 {
     printf("[PeerManager] test_peersDiscovered_empty_list: Testing peersDiscovered with empty peer list...\n");
-    PeerManager mgr(false, nullptr);
+    PeerManager mgr(nullptr, false, nullptr);
 
     QByteArray html = "<html><body></body></html>"; // No <td> tags
     DummyReply* reply = new DummyReply(html);
@@ -275,7 +275,7 @@ END_TEST
 START_TEST(test_error_signal_peerlist_unreachable)
 {
     printf("[PeerManager] test_error_signal_peerlist_unreachable: Testing error signal when peer list server is unreachable...\n");
-    PeerManager mgr(false, nullptr);
+    PeerManager mgr(nullptr, false, nullptr);
 
     DummyReply* reply = new DummyReply("", nullptr);
     reply->setError(QNetworkReply::HostNotFoundError, "Host not found");


### PR DESCRIPTION
This patch implements the private peers configuration as proposed in <https://github.com/the-nexi/yggtray/issues/42>

* src/PeerDiscoveryDialog.h (PeerDiscoveryDialog): Add a private "settings" field.  Add a pointer to a private settings button. (PeerDiscoveryDialog::PeerDiscoveryDialog):
Accept a shared pointer to a settings instance.
* src/PeerDiscoveryDialog.cpp (PeerDiscoveryDialog::PeerDiscoveryDialog): Accept a shared pointer to a settings instance.  Store the pointer into the class field.
(PeerDiscoveryDialog::setupUi): Add "Private peers..." button.  Connect signals.
(PeerDiscoveryDialog::onPrivatePeersClicked): New method.
* src/PeerManager.cpp (PeerManager::PeerManager): Accept a shared pointer to a settings instance.  Store the pointer into the class field.
(PeerManager::handleNetworkResponse): Load private peers from the configuration file.  Prepend the private peers list to the public peers list.
* src/PeerManager.h: Update.
* src/tray.cpp (YggdrasilTray::YggdrasilTray): Accept a shared pointer to a settings instance.  Store the pointer into the class field. (YggdrasilTray::showPeerManager): Pass the shared pointer to a settings instance to the PeerDiscoveryDialog.
* tests/unit/test_peermanager.cpp: Update.
* res/i18n/yggtray_ru.ts: Update.